### PR TITLE
refactor : Add no authorizeHttpRequests URL (5.1.4 접근 거부시 로그인 페이지로 라우…

### DIFF
--- a/src/main/java/com/example/demo/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/demo/config/WebSecurityConfig.java
@@ -30,8 +30,9 @@ public class WebSecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable()) // token 사용해서 basic인증 disable
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // session 기반이 아님을 선언
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/auth/**").permitAll() // /와 /auth/** 경로는 인증 안해도 됨.
-                        .anyRequest().authenticated() // /와 /auth/**이외의 모든 경로는 인증 해야됨.
+                    .requestMatchers("/", "/auth/**", "/error").permitAll()
+                    // /,  /auth/**,  /error 경로는 인증 안해도 됨. 인증되지 않은 유저에게도 error response를 보내고 login 화면으로 돌려야함.
+                    .anyRequest().authenticated() // /, /auth/**, /error 이외의 모든 경로는 인증 해야됨.
                 )
                 .addFilterAfter(jwtAuthenticationFilter, CorsFilter.class); // JWT 필터 등록
         // 책은 http.addFilterAfter()를 따로 호출했지만 메소드 체이닝으로 연결


### PR DESCRIPTION
…팅하기)

Spring Boot 2.6.x 이상 이면,
인증되지 않은 유저에게도 `error response`를 보내고 login 화면으로 돌려야하기 때문에 `WebSecurityConfig` 인증이 필요 없는 경로에 `/error` 를 추가한다. (저자 GitHub Discussions : https://github.com/fsoftwareengineer/todo-application/discussions/41)

Closes: #41